### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-fluent-plugin-glusterfs
+fluent-plugin-glusterfs, a plugin for [Fluentd](http://fluentd.org)
 =======================
 
 fluentd Input plugin for GlusterFS logs.


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
